### PR TITLE
Added Email Notif Config to the seed file

### DIFF
--- a/install/mysql/glpi-seed.sql
+++ b/install/mysql/glpi-seed.sql
@@ -2459,4 +2459,29 @@ VALUES
   ('Monitor', 2005, 11, 0),
   ('Monitor', 2006, 12, 0);
 
+-- === Notification Mailing Settings Seeder ===
+REPLACE INTO glpi_configs (context, name, value) VALUES
+('core', 'admin_email', 'company.tech.wise1@gmail.com'),
+('core', 'admin_email_name', 'GLPI'),
+('core', 'from_email', 'company.tech.wise1@gmail.com'),
+('core', 'from_email_name', 'GLPI'),
+('core', 'replyto_email', 'company.tech.wise1@gmail.com'),
+('core', 'replyto_email_name', 'GLPI'),
+('core', 'noreply_email', ''),
+('core', 'noreply_email_name', ''),
+('core', 'attach_ticket_documents_to_mail', '0'),
+('core', 'mailing_signature', 'Sent by GLPI'),
+('core', 'smtp_mode', '3'),
+('core', 'smtp_max_retries', '5'),
+('core', 'smtp_retry_time', '5'),
+('core', 'smtp_oauth_provider', '0'),
+('core', 'smtp_oauth_client_id', ''),
+('core', 'smtp_oauth_client_secret', ''),
+('core', 'smtp_check_certificate', '1'),
+('core', 'smtp_host', 'smtp.gmail.com'),
+('core', 'smtp_port', '587'),
+('core', 'smtp_username', 'company.tech.wise1@gmail.com'),
+('core', 'smtp_passwd', 'SE+gAcR2wO9/OnDkya/9sGlpZgV90KU4IxdzPP/KV1k='),
+('core', 'smtp_sender', 'company.tech.wise1@gmail.com');
+
 -- End of seed file


### PR DESCRIPTION
Initial Email Notif Configurations are now Added to the Seeder File, But It can't completely Work due to Issues with Encryption, Cant consistently Seed it with a Compatible Value, It need to be added Manually.

Note: To Apply These Changes

Delete config\config_db.php (from the root directory)
Delete the Database from Any Editor or etc (Just remove the glpidb)
Go to GLPI Website and Do the Installation again and db configuration
Run The Seeder Again (Refer to the Previous Pull Request)
Open GLPI and Login

Follow the Video: 
Go to Setup then Notifications
Enable Follow Up, Save
Enable Follow Up Via Email, Save
Go to Email Follow Up Configuration
Add this to SMTP Password "eawu smmo imot kmcg"
Save

Test with, Send a test email to the admin